### PR TITLE
Add a generic role for deploying operators

### DIFF
--- a/roles/deploy-operator/tasks/main.yml
+++ b/roles/deploy-operator/tasks/main.yml
@@ -1,0 +1,68 @@
+# Deploy an operator using OLM
+#
+# Required arguments:
+#   operator: The name of the operator that should be deployed
+#   namespace: The namespace in which the operator will be deployed in.
+#   channel: The channel that will be used to get updates.
+#
+# Optional argumetns:
+#  opm_catalog_source_name: Which catalog source to use when querying
+#  for details about the operator.
+#  
+#  opm_catalog_source_namespace: In which namespace `opm_catalog_source_name`
+#  exist.
+---
+- name: Check for mandatory input
+  assert:
+    that:
+      - operator | string
+      - namespace | string
+      - channel | string
+
+- name: Create Namespace
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ namespace }}"
+
+- name: Create Operator Group
+  k8s:
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: "{{ operator }}"
+        namespace: "{{ namespace }}"
+      spec:
+        targetNamespaces:
+          - "{{ namespace }}"
+
+- name: Create Subscription
+  k8s:
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: "{{ operator }}"
+        namespace: "{{ namespace }}"
+      spec:
+        channel: "{{ channel | string  }}"
+        source: "{{ opm_catalog_source_name | default('redhat-operators') }}"
+        sourceNamespace: "{{ opm_catalog_source_namespace | default('openshift-marketplace') }}"
+        name: "{{ operator }}"
+
+- name: Wait for the CSV to be ready
+  k8s_info:
+    api: operators.coreos.com/v1alpha1
+    namespace: "{{ namespace }}"
+    kind: ClusterServiceVersion
+  register: csv
+  retries: 30
+  delay: 60
+  until:
+    - "csv.resources|length == 1"
+    - "'status' in csv.resources[0]"
+    - "'phase' in csv.resources[0].status"
+    - ("csv.resources[0].status.phase == 'Succeeded'" or "csv.resources[0].status.phase == 'Present'")


### PR DESCRIPTION
When deploying and operator based product, the first step is to ask
OLM to run its operator. This step is the same for all the products,
so it makes sense to have a generic role for it.

The role can be used for different operators by calling it with
different parameters.

Signed-off-by: gbenhaim <gbenhaim@redhat.com>