### PR TITLE
Add generic role for deploying crs

### DIFF
--- a/roles/deploy-cr/tasks/main.yml
+++ b/roles/deploy-cr/tasks/main.yml
@@ -1,0 +1,61 @@
+# Deploy a custom resource
+#
+# Required arguments:
+#   api_version: The api version, including the namespace of the CR
+#   (e.g hco.kubevirt.io/v1beta1)
+#
+#   namespace: The namespace in which the CR should be created
+#
+#   kind: The kind of the CR
+#
+#   name: The name that will be used to identify the CR
+#
+#   spec: The spec field of the CR.
+---
+- name: Check for mandatory input
+  assert:
+    that:
+      - api_version | string
+      - kind | string
+      - namespace | string
+      - name | string
+      - spec is mapping
+
+- name: Deploy CR
+  k8s:
+    definition:
+      apiVersion: "{{ api_version }}"
+      kind: "{{ kind }}"
+      metadata:
+        name: "{{ name }}"
+        namespace: "{{ namespace }}"
+      spec: "{{ spec }}"
+  register: result
+  retries: 5
+  delay: 60
+  until: result is not failed
+
+- name: Check that the CR is ready
+  community.kubernetes.k8s_info:
+    api_version: "{{ api_version }}"
+    namespace: "{{ namespace }}"
+    kind: "{{ kind }}"
+    wait: true
+    wait_condition:
+      type: Available
+      status: "True"
+    wait_timeout: 3600
+
+- name: Wait for the CSV to be ready
+  k8s_info:
+    api: operators.coreos.com/v1alpha1
+    namespace: "{{ namespace }}"
+    kind: ClusterServiceVersion
+  register: csv
+  retries: 30
+  delay: 60
+  until:
+    - "csv.resources|length == 1"
+    - "'status' in csv.resources[0]"
+    - "'phase' in csv.resources[0].status"
+    - "csv.resources[0].status.phase == 'Succeeded'"

--- a/roles/deploy-operator/tasks/main.yml
+++ b/roles/deploy-operator/tasks/main.yml
@@ -1,0 +1,68 @@
+# Deploy an operator using OLM
+#
+# Required arguments:
+#   operator: The name of the operator that should be deployed
+#   namespace: The namespace in which the operator will be deployed in.
+#   channel: The channel that will be used to get updates.
+#
+# Optional argumetns:
+#  opm_catalog_source_name: Which catalog source to use when querying
+#  for details about the operator.
+#  
+#  opm_catalog_source_namespace: In which namespace `opm_catalog_source_name`
+#  exist.
+---
+- name: Check for mandatory input
+  assert:
+    that:
+      - operator | string
+      - namespace | string
+      - channel | string
+
+- name: Create Namespace
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ namespace }}"
+
+- name: Create Operator Group
+  k8s:
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: "{{ operator }}"
+        namespace: "{{ namespace }}"
+      spec:
+        targetNamespaces:
+          - "{{ namespace }}"
+
+- name: Create Subscription
+  k8s:
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: "{{ operator }}"
+        namespace: "{{ namespace }}"
+      spec:
+        channel: "{{ channel | string  }}"
+        source: "{{ opm_catalog_source_name | default('redhat-operators') }}"
+        sourceNamespace: "{{ opm_catalog_source_namespace | default('openshift-marketplace') }}"
+        name: "{{ operator }}"
+
+- name: Wait for the CSV to be ready
+  k8s_info:
+    api: operators.coreos.com/v1alpha1
+    namespace: "{{ namespace }}"
+    kind: ClusterServiceVersion
+  register: csv
+  retries: 30
+  delay: 60
+  until:
+    - "csv.resources|length == 1"
+    - "'status' in csv.resources[0]"
+    - "'phase' in csv.resources[0].status"
+    - ("csv.resources[0].status.phase == 'Succeeded'" or "csv.resources[0].status.phase == 'Present'")


### PR DESCRIPTION
  Add a role for deploying a CR
  
  In order to let the operator know that an instance of the application
  is needed, we need to create a CR.
  
  The process of creating a CR is the same for any operator.
  The spec of the CR can be passed to the role as an argument.

Depends on https://github.com/redhat-cip/dci-openshift-agent/pull/6
  
  Signed-off-by: gbenhaim <gbenhaim@redhat.com>