### PR TITLE
Remove duplicated host_key_checking entry

### DIFF
--- a/samples/ansible.cfg
+++ b/samples/ansible.cfg
@@ -2,4 +2,3 @@
 inventory           = /etc/dci-openshift-agent/hosts
 roles_path          = /usr/share/dci/roles/
 host_key_checking   = False
-host_key_checking   = False


### PR DESCRIPTION
Fixes the error:

`Error reading config file (/var/lib/dci-openshift-agent/samples/ansible.cfg): While reading from '<string>' [line  5]: option 'host_key_checking' in section 'defaults' already exists`