### PR TITLE
Use json output for ip command

### DIFF
--- a/plays/ipi-install.yml
+++ b/plays/ipi-install.yml
@@ -96,7 +96,7 @@
     vars:
       target_ip: "{{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }}"
     shell:
-      cmd: /usr/sbin/ip route get {{ target_ip }}
+      cmd: /usr/sbin/ip -j route get {{ target_ip }}
     register: aw_route
     delegate_to: localhost
 
@@ -109,7 +109,7 @@
 
   - name: "Get firewall zone in controller"
     vars:
-      aw_interface: "{{ aw_route.stdout_lines[0].split(' ')[2] }}"
+      aw_interface: "{{ aw_route.stdout | from_json | community.general.json_query('[].dev') }}"
       zone_interfaces: "{{ aw_fw_zones.firewalld_info.zones[zone].interfaces }}"
     set_fact:
       aw_zone: "{{ zone }}"


### PR DESCRIPTION
Where the provisioning node is also the bastion node, the result of the `ip r` is a bit different, which make the split line not to work for us. Using the JSON output give us an object we can work with.

```sh
# ip r get to 169.55.126.157
local 169.55.126.157 dev lo src 169.55.126.157 uid 0 
    cache <local> 

#  ip r get to 169.55.126.1
169.55.126.1 via 169.55.126.145 dev baremetal src 169.55.126.157 uid 0 
    cache 
```

```
[root@ep ~]# ip -j r get to 169.55.126.1 | jq . 
[
  {
    "dst": "169.55.126.1",
    "gateway": "169.55.126.145",
    "dev": "baremetal",
    "prefsrc": "169.55.126.157",
    "flags": [],
    "uid": 0,
    "cache": []
  }
]
[root@ep ~]# ip -j r get to 169.55.126.157 | jq . 
[
  {
    "type": "local",
    "dst": "169.55.126.157",
    "dev": "lo",
    "prefsrc": "169.55.126.157",
    "flags": [],
    "uid": 0,
    "cache": [
      "local"
    ]
  }
]
```