### PR TITLE
Changed retries count to cover compact cluster

### DIFF
--- a/plays/after-install.yml
+++ b/plays/after-install.yml
@@ -75,7 +75,7 @@
     api: metal3.io/v1alpha1
     namespace: openshift-machine-api
   register: bmh_info
-  retries: "{{ requested_compute | int * 10 + 1 }}"
+  retries: "{{ (requested_compute | int + 1) * 10 }}"
   delay: 30
   until: bmh_unique_states == ['provisioned']
   when:


### PR DESCRIPTION
With compact clusters, the `requested_compute` will be 0, and the end result will be a single retry, which in some cases will not be enough, and we might fail as the state will be `registering`